### PR TITLE
feat: add refresh token functionality

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,9 @@
 
 # # JWT Configuration
 # JWT_SECRET=your-jwt-secret-key-change-in-production
+# JWT_REFRESH_SECRET=your-jwt-secret-key-change-in-production
+# JWT_EXPIRY=your-expiry-for-access-token-ideal-set-it-to-15m
+# JWT_REFRESH_EXPIRY=your-expiry-for-refresh-token-ideal-set-it-to-7d
 
 # # Session Configuration
 # SESSION_SECRET=your-session-secret-key-change-in-production

--- a/backend/index.js
+++ b/backend/index.js
@@ -16,9 +16,12 @@ const { passport: passportInstance, configureOAuthStrategies } = require(path.jo
 require('dotenv').config();
 
 const createAuthBackend = (config = {}) => {
-  const {
+  const { 
     mongoUri = 'mongodb://localhost:27017/mern-auth',
     jwtSecret = 'your-secret-key-change-in-production',
+    jwtExpiry = '15m', //your-expiry-for-access-token-ideal-set-it-to-15m',
+    jwtRefreshSecret = 'your-secret-key-change-in-production',
+    jwtRefreshExpiry = '7d', //'your-expiry-for-refresh-token-ideal-set-it-to-7d',
     corsOrigin = 'http://localhost:5173',
     cookieMaxAge = 7 * 24 * 60 * 60 * 1000, // 7 days
     enableOAuth = false, // OAuth disabled by default
@@ -41,6 +44,9 @@ const createAuthBackend = (config = {}) => {
   app.use(cookieParser());
   app.use(session({
     secret: jwtSecret,
+    expiry: jwtExpiry,
+    refreshSecret: jwtRefreshSecret,
+    refreshExpiry: jwtRefreshExpiry,
     resave: false,
     saveUninitialized: false,
     store: MongoStore.create({
@@ -80,6 +86,9 @@ const createAuthBackend = (config = {}) => {
   // Make config available to routes
   app.locals.authConfig = {
     jwtSecret,
+    jwtExpiry,
+    jwtRefreshSecret,
+    jwtRefreshExpiry,
     cookieMaxAge,
     corsOrigin,
     enableOAuth,

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -24,6 +24,9 @@ const userSchema = new mongoose.Schema({
     },
     minlength: 6
   },
+  refreshToken: {
+    type: String
+  }, // For refreshtokens to generate new accesstokens
   googleId: String,
   githubId: String,
   authMethod: {


### PR DESCRIPTION
**what's added,** 

1. refresh token generation: new generateRefreshToken helper function to create and sign refresh tokens.
2. refresh token storage: refresh tokens are now stored securely in the user's database document upon sign-in and oauth callbacks.
3. "/refresh-token" endpoint: a new api endpoint that allows clients to obtain a new access token using a valid refresh token.
4. token rotation: upon successful refresh, a new refresh token is issued, and the old one is invalidated to improve security against token theft (refresh token rotation).
5. reuse detection: added logic to detect and handle refresh token reuse attempts, forcing a re-login for security.
6. cookie handling: access and refresh tokens are set as http-only, secure cookies with appropriate maxAge based on their respective expiry times.


**how to test,**
1. sign up/sign in: log in with a regular user or via google/github oauth.
2. observe cookies: check your browser's application tab; you should see both authToken and refreshToken cookies.
3. simulate access token expiration: you can manually tamper with the authToken cookie or set a very short jwtExpiry in your config (e.g., '10s') for testing.
4. call refresh token endpoint: make a post request to /api/auth/refresh-token (ensure your refreshToken cookie is present in the request or sent in the body if you remove the cookie).
5. verify new tokens: confirm that new authToken and refreshToken cookies are issued and that the response contains the accessToken.
6. test reuse: attempt to use the old refreshToken after a successful refresh, it should be rejected.

gg.
